### PR TITLE
Add password strength indicator on Register page for improved UX and …

### DIFF
--- a/frontend/src/Components/auth/Register.jsx
+++ b/frontend/src/Components/auth/Register.jsx
@@ -15,7 +15,19 @@ const Register = () => {
   const [passwordMatch, setPasswordMatch] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordStrength, setPasswordStrength] = useState(0);
   const navigate = useNavigate();
+
+  // Password strength checker — returns score from 0 to 4
+  const getPasswordStrength = (password) => {
+    let score = 0;
+    if (!password) return score;
+    if (password.length >= 8) score++;
+    if (/[A-Z]/.test(password)) score++;
+    if (/[0-9]/.test(password)) score++;
+    if (/[^A-Za-z0-9]/.test(password)) score++;
+    return score;
+  };
 
   // Handle input change
   const handleChange = (e) => {
@@ -24,6 +36,10 @@ const Register = () => {
       ...formData,
       [name]: value,
     });
+
+    if (name === "password") {
+      setPasswordStrength(getPasswordStrength(value));
+    }
 
     if (name === "password" || name === "confirmPassword") {
       if (name === "confirmPassword" && value !== formData.password) {
@@ -178,6 +194,26 @@ const Register = () => {
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
+
+              {/* Password Strength Indicator — initially hidden if password empty */}
+              {formData.password && (
+                <div className="mt-1">
+                  <div className="h-2 w-full rounded bg-gray-300">
+                    <div
+                      className={`h-2 rounded ${
+                        passwordStrength === 0 ? "w-1/4 bg-red-500" :
+                        passwordStrength === 1 ? "w-1/4 bg-red-500" :
+                        passwordStrength === 2 ? "w-2/4 bg-yellow-400" :
+                        passwordStrength === 3 ? "w-3/4 bg-blue-500" :
+                        "w-full bg-green-500"
+                      } transition-all duration-300`}
+                    />
+                  </div>
+                  <p className="text-sm mt-1 font-medium text-[#1D3557]">
+                    {["Too weak", "Weak", "Fair", "Good", "Strong"][passwordStrength]}
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* Confirm Password */}


### PR DESCRIPTION
🚀 Pull Request Checklist
Please ensure the following before requesting a review:

 - [X] ✅ My issue is assigned to me, and I have not taken up another task simultaneously.
 - [X]  🔁 I have pulled the latest changes from the main branch.
- [X]  🧪 My code is tested and does not break existing functionality.
 - [ ]📚 I have added/updated documentation wherever necessary.
 - [X] 🧹 My code follows the project’s coding standards.
- [X]  ✍️ My commits are clear and meaningful.
- [X]  🧾 I have linked the issue this PR addresses with Closes #72.

📌 Related Issue
Closes #72 

🧠 Description
This PR adds a real-time password strength indicator to the Register component. The indicator evaluates password strength based on length, presence of uppercase letters, numbers, and special characters. A colored strength bar and descriptive text display below the password input field, updating live as the user types. The indicator is initially hidden and appears only when the user starts typing a password.

This enhancement improves user security awareness and experience by guiding users to create stronger passwords during registration.

✅ Type of Change
 🐞 Bug fix
 - [X]💡 Feature
 🧹 Code cleanup/refactor
 🧪 Test cases
 📚 Docs update
 
 Screenshots:
 
<img width="562" height="876" alt="Screenshot 2025-08-25 181229" src="https://github.com/user-attachments/assets/0b949264-ab24-41bb-86c3-183742841f58" />
<img width="560" height="890" alt="Screenshot 2025-08-25 181243" src="https://github.com/user-attachments/assets/68fbeefb-d77b-46ad-b27e-7c9344e59ee9" />

<img width="561" height="877" alt="Screenshot 2025-08-25 181222" src="https://github.com/user-attachments/assets/ec193fc4-9a74-4460-81d8-3a2b95198d6a" />

