### PR TITLE
Display Pomodoro Timer in Navbar on Protected Pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import AdStrip from "./Components/Ad";
 import { FeaturesSection } from "./Components/Features";
 import Footer from "./Components/footer";
 import ScrollRevealWrapper from "./Components/ui/ScrollRevealWrapper";
-import Loader from "./Components/ui/Loader"; // ✅ Import the Loader
+import Loader from "./Components/ui/Loader";
 import ContributorsSection from "./Components/Contributors";
 import AllContributors from "./Components/AllContributors";
 
@@ -20,20 +20,13 @@ import Profile from "./Components/profile/Profile";
 import ProtectedRoute from "./Components/auth/ProtectedRoute";
 import Dashboard from "./Components/Dashboard";
 import Pomodoro from "./Components/DashBoard/Pomodoro";
-import { ArrowUp } from "lucide-react"; 
+import { ArrowUp } from "lucide-react";
 
 function Home() {
   const [showTop, setShowTop] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (window.scrollY > 300) {
-        setShowTop(true);
-      } else {
-        setShowTop(false);
-      }
-    };
-
+    const handleScroll = () => setShowTop(window.scrollY > 300);
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
@@ -41,14 +34,10 @@ function Home() {
   const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
 
   return (
-
-  <div className="min-h-screen w-full bg-[var(--background)] scroll-smooth overflow-hidden">
-
-      {/* Navbar */}
+    <div className="min-h-screen w-full bg-[var(--background)] scroll-smooth overflow-hidden">
       <Navbar />
 
-      {/* Main Content */}
-  <main className="relative z-10 px-4 py-24 text-[var(--foreground)]">
+      <main className="relative z-10 px-4 py-24 text-[var(--foreground)]">
         <ScrollRevealWrapper>
           <div id="home">
             <Hero />
@@ -68,29 +57,23 @@ function Home() {
         <div id="about">
           <About />
         </div>
+
         <ScrollRevealWrapper delay={0.2}>
           <div id="contact">
             <Contact />
           </div>
         </ScrollRevealWrapper>
-        <ContributorsSection/>
+
+        <ContributorsSection />
         <Footer />
       </main>
 
-      {/* ✅ Back to Top Button */}
-  
-{showTop && (
-  <button
-    onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-    className="fixed bottom-6 right-6 p-3 rounded-full shadow-lg transition-all duration-300 z-50 bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)]"
-
-  >
-    <ArrowUp size={20} />
-  </button>
-)}
-
+      {/* Back to Top Button */}
       {showTop && (
-        <button onClick={scrollToTop} className="fixed bottom-6 right-6 p-3 rounded-full shadow-lg transition-all duration-300 z-50 bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)]">
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-6 right-6 p-3 rounded-full shadow-lg transition-all duration-300 z-50 bg-[var(--primary)] text-[var(--primary-foreground)] hover:bg-[var(--accent)]"
+        >
           <ArrowUp size={20} />
         </button>
       )}
@@ -100,12 +83,9 @@ function Home() {
 
 function App() {
   const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    // Simulate initial app/data loading
-    const timer = setTimeout(() => {
-      setLoading(false);
-    }, 2000); // adjust delay if needed
 
+  useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), 2000);
     return () => clearTimeout(timer);
   }, []);
 
@@ -115,27 +95,45 @@ function App() {
         <Loader size="lg" />
       </div>
     );
-   }
-
- 
-  if (loading) return (
-    <div className="min-h-screen flex items-center justify-center bg-[var(--background)]">
-      <Loader size="lg" />
-    </div>
-  );
+  }
 
   return (
     <TimerProvider>
       <Routes>
+        {/* Public Routes */}
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
-        <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/pomodoro" element={<Pomodoro />} />
-        <Route path='/contributors' element={<AllContributors/>}/>
-    </Routes>
+        <Route path="/contributors" element={<AllContributors />} />
+
+        {/* Protected Routes */}
+        <Route
+          path="/profile"
+          element={
+            <ProtectedRoute>
+              <Profile />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/pomodoro"
+          element={
+            <ProtectedRoute>
+              <Pomodoro />
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
     </TimerProvider>
   );
 }
+
 export default App;

--- a/frontend/src/Components/DashBoard/Pomodoro.jsx
+++ b/frontend/src/Components/DashBoard/Pomodoro.jsx
@@ -1,20 +1,28 @@
 // src/Components/DashBoard/Pomodoro.jsx
-import React from 'react';
+import React from "react";
 import { useTimer } from "../../context/TimerContext";
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from "react-router-dom";
 
 const Pomodoro = () => {
   const navigate = useNavigate();
-  const { timeLeft, isWork, startTimer, pauseTimer, resetTimer } = useTimer();
+  const {
+    timeLeft,
+    isWork,
+    isActive,
+    startTimer,
+    pauseTimer,
+    resetTimer,
+  } = useTimer();
 
   const formatTime = (seconds) => {
-    const mins = String(Math.floor(seconds / 60)).padStart(2, '0');
-    const secs = String(seconds % 60).padStart(2, '0');
+    const mins = String(Math.floor(seconds / 60)).padStart(2, "0");
+    const secs = String(seconds % 60).padStart(2, "0");
     return `${mins}:${secs}`;
-  };  
+  };
 
   return (
-    <section className="min-h-screen bg-[#DCE6EC] flex flex-col items-center justify-center px-4 md:px-10">
+    <section className="min-h-screen bg-[#DCE6EC] flex flex-col items-center justify-center px-4 md:px-10 relative">
+      {/* Close button */}
       <button
         onClick={() => navigate(-1)}
         className="absolute top-4 right-4 bg-red-500 text-white px-4 py-2 rounded text-sm sm:text-base md:text-lg"
@@ -26,39 +34,49 @@ const Pomodoro = () => {
         POMODORO TIMER!
       </h2>
 
-      <h4
-        className={`absolute top-20 px-4 py-2 sm:px-6 sm:py-2 rounded text-white text-lg sm:text-xl md:text-2xl ${
-          isWork ? 'bg-green-500' : 'bg-blue-500'
-        }`}
-      >
-        {isWork ? 'Work Session' : 'Take a Break'}
-      </h4>
+      {/* Session label */}
+      {isActive && (
+        <h4
+          className={`absolute top-20 px-4 py-2 sm:px-6 sm:py-2 rounded text-white text-lg sm:text-xl md:text-2xl ${
+            isWork ? "bg-green-500" : "bg-blue-500"
+          }`}
+        >
+          {isWork ? "Work Session" : "Take a Break"}
+        </h4>
+      )}
 
       <div className="text-center mt-20 w-full">
-        <h1 className="text-[70px] sm:text-[100px] md:text-[130px] lg:text-[170px] font-bold">
-          {formatTime(timeLeft)}
-        </h1>
+        {isActive ? (
+          <>
+            {/* Timer */}
+            <h1 className="text-[70px] sm:text-[100px] md:text-[130px] lg:text-[170px] font-bold">
+              {formatTime(timeLeft)}
+            </h1>
 
-        <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-6">
+            {/* Controls */}
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-6">
+              <button
+                onClick={pauseTimer}
+                className="bg-orange-400 text-black px-6 py-3 sm:px-8 sm:py-3 text-lg sm:text-xl md:text-2xl rounded shadow-md font-bold hover:scale-105 duration-100"
+              >
+                Pause
+              </button>
+              <button
+                onClick={resetTimer}
+                className="bg-red-400 text-black px-6 py-3 sm:px-8 sm:py-3 text-lg sm:text-xl md:text-2xl rounded shadow-md font-bold hover:scale-105 duration-100"
+              >
+                Reset
+              </button>
+            </div>
+          </>
+        ) : (
           <button
             onClick={startTimer}
             className="bg-yellow-400 text-black px-6 py-3 sm:px-8 sm:py-3 text-lg sm:text-xl md:text-2xl rounded shadow-md font-bold hover:scale-105 duration-100"
           >
-            Start
+            Start Pomodoro
           </button>
-          <button
-            onClick={pauseTimer}
-            className="bg-orange-400 text-black px-6 py-3 sm:px-8 sm:py-3 text-lg sm:text-xl md:text-2xl rounded shadow-md font-bold hover:scale-105 duration-100"
-          >
-            Pause
-          </button>
-          <button
-            onClick={resetTimer}
-            className="bg-red-400 text-black px-6 py-3 sm:px-8 sm:py-3 text-lg sm:text-xl md:text-2xl rounded shadow-md font-bold hover:scale-105 duration-100"
-          >
-            Reset
-          </button>
-        </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
# 🚀 Pull Request Checklist

> **Please ensure the following before requesting a review:**

- [x] ✅ My issue is **assigned to me**, and I have not taken up another task simultaneously.
- [x] 🔁 I have pulled the latest changes from the `main` branch.
- [x] 🧪 My code is **tested** and does not break existing functionality.
- [] 📚 I have added/updated **documentation** wherever necessary.
- [x] 🧹 My code follows the **project’s coding standards**.
- [x] ✍️ My commits are **clear and meaningful**.
- [x] 🧾 I have linked the issue this PR addresses with `Closes #<issue_number>`.

---

## 📌 Related Issue

Closes #<issue_number>

## 🧠 Description

> This PR updates the Pomodoro timer functionality in DevSync:

- Timer is now only visible after being **activated**.
- Timer is only accessible on **protected routes** (pages requiring login).
- Timer state persists across page navigation using **localStorage**.
- Added `isActive` state in `TimerContext` to control visibility.
- Navbar now respects timer visibility.

_Screenshots/GIFs:_

- Timer start button
- Timer running state on Dashboard/Pomodoro page
- Timer pause/reset functionality

---

## ✅ Type of Change

- [x] 💡 Feature
- [ ] 🐞 Bug fix
- [ ] 🧹 Code cleanup/refactor
- [ ] 🧪 Test cases
- [ ] 📚 Docs update

---

## 📝 Additional Notes (Optional)

- Tested timer across multiple page navigations.
- Verified that timer does not appear on public routes (unauthenticated pages).
