### PR TITLE
Fix: Improve contrast of contact form header in dark mode

### DIFF
--- a/frontend/src/Components/contact.jsx
+++ b/frontend/src/Components/contact.jsx
@@ -93,7 +93,7 @@ const Contact = () => {
         >
           <div className="flex items-center justify-center mb-6 space-x-2">
             <MessageCircle className="w-10 h-10 text-blue-600 animate-bounce" />
-            <h1 className="text-3xl font-bold text-gray-800">Contact Us</h1>
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white">Contact Us</h1>
           </div>
 
           <div className="text-center w-full z-10">


### PR DESCRIPTION
🚀 Pull Request Checklist

[x] ✅ My issue is assigned to me, and I have not taken up another task simultaneously.

[x] 🔁 I have pulled the latest changes from the main branch.

[x] 🧪 My code is tested and does not break existing functionality.

[ ] 📚 I have added/updated documentation wherever necessary.

[x] 🧹 My code follows the project’s coding standards.

[x] ✍️ My commits are clear and meaningful.

[x] 🧾 I have linked the issue this PR addresses with Closes #158.

📌 Related Issue
Closes #158

🧠 Description
This PR resolves a UI/Accessibility issue on the Contact Us page where the main header text ("Contact Us") had poor color contrast in dark mode, making it difficult to read.

The fix utilizes Tailwind CSS's dark: variant to apply a high-contrast white text color in dark mode while retaining the original dark grey text for light mode. This ensures the header is legible and meets accessibility standards across both themes.

Before (Dark Mode):
<img width="1576" height="806" alt="image" src="https://github.com/user-attachments/assets/ccdbae63-2a39-4e6c-bd86-f3ee0c3cb77c" />

After (Dark Mode):
<img width="1599" height="796" alt="image" src="https://github.com/user-attachments/assets/539bb589-be81-4c42-bdd2-becbbc9a7724" />

After (Light Mode):
<img width="1571" height="798" alt="image" src="https://github.com/user-attachments/assets/4b997709-450c-45a1-959f-da5f87d9fd60" />

✅ Type of Change
[x] 🐞 Bug fix

[ ] 💡 Feature

[ ] 🧹 Code cleanup/refactor

[ ] 🧪 Test cases

[ ] 📚 Docs update

📝 Additional Notes (Optional)
Happy to contribute for Hacktoberfest 2025! This change improves the overall user experience and accessibility of the contact form. Please let me know if any further modifications are required.
